### PR TITLE
Fixing skiplist affecting whole repo

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -10,7 +10,7 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-const VERSION = "0.1.0"
+const VERSION = "0.1.1"
 
 type App struct {
 	config c.IConfig

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -196,16 +196,29 @@ func TestApp_ListRepositories(t *testing.T) {
 }
 
 func TestApp_DeleteRepositories(t *testing.T) {
+	// construct sample data from sample repo with some additions to match with the test case
+	var repoWithMoreDigest []reg.Repository
+	repoWithMoreDigest = append(repoWithMoreDigest, sampleRepos...)
 	deleteRepoDigest := reg.Digest{
-
 		Name:           "sha256:01551c49819f8bda0a8bdc6216e5793404b0adb4937d407e99a590c0c5cb8078",
 		ImageSizeBytes: 488119934,
 		Tag:            []string{"release-prod-abc"},
 		Created:        time.Date(2022, time.Month(2), 21, 1, 10, 30, 0, time.UTC),
 		Uploaded:       time.Date(2022, time.Month(2), 21, 1, 10, 30, 0, time.UTC),
 	}
-	repoWithMoreDigest := sampleRepos
 	repoWithMoreDigest[0].Digests = append(repoWithMoreDigest[0].Digests, deleteRepoDigest)
+	repoWithMoreDigest = append(repoWithMoreDigest, reg.Repository{
+		Name: "image-3",
+		Digests: []reg.Digest{
+			{
+				Name:           "sha256:B0ac9df37ff356753cd20f4475d4b8d3a543b4d45db2390c0275be2ee7a0xyz",
+				ImageSizeBytes: 488118834,
+				Tag:            []string{"abc", "def"},
+				Created:        time.Date(2021, time.Month(2), 21, 1, 10, 30, 0, time.UTC),
+				Uploaded:       time.Date(2021, time.Month(2), 21, 1, 10, 30, 0, time.UTC),
+			},
+		},
+	})
 
 	testCases := map[string]struct {
 		mockConfig   func(*gomock.Controller) *mc.MockIConfig
@@ -235,7 +248,7 @@ func TestApp_DeleteRepositories(t *testing.T) {
 
 				mockConfig := mc.NewMockIConfig(ctrl)
 				mockConfig.EXPECT().ImageRegistry().Times(2).Return(mockReg)
-				mockConfig.EXPECT().SkipList().Times(1).Return([]string{"image-1:latest"})
+				mockConfig.EXPECT().SkipList().Times(1).Return([]string{"image-1:latest", "image-3:abc", "image-3:def"})
 				mockConfig.EXPECT().IsDryRun().Times(2).Return(false)
 				return mockConfig
 			},


### PR DESCRIPTION
# Background

if we has skip list file as follow:
```
repo1/image1:latest
```
and the results of listing repository 
```
repo1/image1:latest
repo1/image1:release-abc
repo1/image2:latest
```
It only removing `repo1/image2:latest` whereas the other `image1:release-abc` will not deleted

# Fix

This MR will also removing the other image under image1 that not listing in skiplist, so it will remove `repo1/image2:release-abc` as well. 