### PR TITLE
Refactor deletion logic

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,12 @@
 
 name: tests
-on: [pull_request, workflow_dispatch]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - '**'
 
 env:
   GO_VERSION: 1.18

--- a/app/app.go
+++ b/app/app.go
@@ -37,8 +37,14 @@ func (a App) DeleteRepositories(repositories []reg.Repository) (err error) {
 			log.Warn().Str("repo", repo.Name).Msg("no digest found as for deleting in repository, skip it")
 			continue
 		}
+
+		if a.config.IsDryRun() {
+			log.Info().Str("repo", repo.Name).Msg("[DRY_RUN] attempting for deletion")
+			continue
+		}
+
 		log.Info().Str("repo", repo.Name).Msg("deleting repository")
-		if err = a.config.ImageRegistry().Delete(repo, a.config.IsDryRun()); err != nil {
+		if err = a.config.ImageRegistry().Delete(repo); err != nil {
 			return err
 		}
 	}

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -228,7 +228,7 @@ func TestApp_DeleteRepositories(t *testing.T) {
 		"got an error while deleting image": {
 			mockConfig: func(ctrl *gomock.Controller) *mc.MockIConfig {
 				mockReg := mr.NewMockImageRegistry(ctrl)
-				mockReg.EXPECT().Delete(sampleRepos[0], false).Times(1).Return(fmt.Errorf("failure"))
+				mockReg.EXPECT().Delete(sampleRepos[0]).Times(1).Return(fmt.Errorf("failure"))
 
 				mockConfig := mc.NewMockIConfig(ctrl)
 				mockConfig.EXPECT().ImageRegistry().Times(1).Return(mockReg)
@@ -243,13 +243,23 @@ func TestApp_DeleteRepositories(t *testing.T) {
 			mockConfig: func(ctrl *gomock.Controller) *mc.MockIConfig {
 				mockReg := mr.NewMockImageRegistry(ctrl)
 				expetedDeleteRepoImage1 := reg.Repository{Name: "image-1", Digests: []reg.Digest{deleteRepoDigest}}
-				mockReg.EXPECT().Delete(repoWithMoreDigest[1], false).Times(1).Return(nil)
-				mockReg.EXPECT().Delete(expetedDeleteRepoImage1, false).Times(1).Return(nil)
+				mockReg.EXPECT().Delete(repoWithMoreDigest[1]).Times(1).Return(nil)
+				mockReg.EXPECT().Delete(expetedDeleteRepoImage1).Times(1).Return(nil)
 
 				mockConfig := mc.NewMockIConfig(ctrl)
 				mockConfig.EXPECT().ImageRegistry().Times(2).Return(mockReg)
 				mockConfig.EXPECT().SkipList().Times(1).Return([]string{"image-1:latest", "image-3:abc", "image-3:def"})
 				mockConfig.EXPECT().IsDryRun().Times(2).Return(false)
+				return mockConfig
+			},
+			repositories: repoWithMoreDigest,
+		},
+		"will not calling registry delete api when dry run is set": {
+			mockConfig: func(ctrl *gomock.Controller) *mc.MockIConfig {
+				mockConfig := mc.NewMockIConfig(ctrl)
+				mockConfig.EXPECT().ImageRegistry().Times(0)
+				mockConfig.EXPECT().SkipList().Times(1).Return([]string{})
+				mockConfig.EXPECT().IsDryRun().Times(3).Return(true)
 				return mockConfig
 			},
 			repositories: repoWithMoreDigest,

--- a/pkg/registry/gcr.go
+++ b/pkg/registry/gcr.go
@@ -118,7 +118,7 @@ func (g *GCR) tagList(repository string) (err error) {
 	return nil
 }
 
-func (g GCR) Delete(repository Repository, isDryRun bool) (err error) {
+func (g GCR) Delete(repository Repository) (err error) {
 	shortRepoName := strings.TrimPrefix(repository.Name, fmt.Sprintf("%s/", g.host))
 	manifestURL := fmt.Sprintf("https://%s/v2/%s/manifests", g.host, shortRepoName)
 	for idr := range repository.Digests {
@@ -126,13 +126,13 @@ func (g GCR) Delete(repository Repository, isDryRun bool) (err error) {
 		// delete the related tags
 		for idt := range digest.Tag {
 			tagURL := fmt.Sprintf("%s/%s", manifestURL, digest.Tag[idt])
-			if err = deleteImage(g.hc, tagURL, isDryRun); err != nil {
+			if err = deleteImage(g.hc, tagURL); err != nil {
 				return err
 			}
 		}
 
 		digestURL := fmt.Sprintf("%s/%s", manifestURL, digest.Name)
-		if err = deleteImage(g.hc, digestURL, isDryRun); err != nil {
+		if err = deleteImage(g.hc, digestURL); err != nil {
 			return err
 		}
 	}

--- a/pkg/registry/mock_registry/mock_registry.go
+++ b/pkg/registry/mock_registry/mock_registry.go
@@ -50,15 +50,15 @@ func (mr *MockImageRegistryMockRecorder) Catalog() *gomock.Call {
 }
 
 // Delete mocks base method.
-func (m *MockImageRegistry) Delete(repo registry.Repository, isDryRun bool) error {
+func (m *MockImageRegistry) Delete(repo registry.Repository) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", repo, isDryRun)
+	ret := m.ctrl.Call(m, "Delete", repo)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Delete indicates an expected call of Delete.
-func (mr *MockImageRegistryMockRecorder) Delete(repo, isDryRun interface{}) *gomock.Call {
+func (mr *MockImageRegistryMockRecorder) Delete(repo interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockImageRegistry)(nil).Delete), repo, isDryRun)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockImageRegistry)(nil).Delete), repo)
 }

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -7,7 +7,6 @@ import (
 	"regexp"
 
 	"github.com/iomarmochtar/cir-rotator/pkg/http"
-	"github.com/rs/zerolog/log"
 	"golang.org/x/oauth2"
 )
 
@@ -55,16 +54,11 @@ type Repository struct {
 //go:generate mockgen -destination mock_registry/mock_registry.go -source registry.go ImageRegistry
 type ImageRegistry interface {
 	Catalog() ([]Repository, error)
-	Delete(repo Repository, isDryRun bool) error
+	Delete(repo Repository) error
 }
 
 // deleteImage shorthand for deleting image
-func deleteImage(hc http.IHttpClient, url string, isDryRun bool) (err error) {
-	if isDryRun {
-		log.Info().Str("url", url).Msg("[DRY_RUN] attempting for deletion")
-		return nil
-	}
-
+func deleteImage(hc http.IHttpClient, url string) (err error) {
 	var errResp ErrorsField
 	if err = hc.DeleteMarshalReturnObj(url, &errResp); err != nil {
 		return err


### PR DESCRIPTION
# Background

In previous implementation we set dry run logic in to registry implementation, this way will cause not centralized logic and may some of registry will have the wrong one. so then will be better if it's centralized in app logic instead so registry impl will focusing to the actual one. 